### PR TITLE
docs: generate usage and some smaller stuff

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2016 The Borg Collective (see AUTHORS file)
+Copyright (C) 2016-2017 The Borg Collective (see AUTHORS file)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,5 +1,9 @@
 .. include:: global.rst.inc
 
+=================
+Authors & License
+=================
+
 .. include:: ../AUTHORS
 
 License

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -34,6 +35,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'usage',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -54,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Borg - Import'
-copyright = '2016 The Borg Collective (see AUTHORS file)'
+copyright = '2016-2017 The Borg Collective (see AUTHORS file)'
 author = 'The Borg Collective'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,5 @@
 .. include:: global.rst.inc
 
-
 Borg-Import Documentation
 =========================
 

--- a/docs/usage.py
+++ b/docs/usage.py
@@ -1,0 +1,109 @@
+from textwrap import dedent, indent
+
+import sphinx.application
+from docutils.parsers.rst import Directive
+from docutils import nodes
+from docutils.statemachine import StringList
+from sphinx.util.nodes import nested_parse_with_titles
+
+from borg_import.main import build_parser
+
+
+class GenerateUsageDirective(Directive):
+    required_arguments = 1
+    has_content = False
+
+    @staticmethod
+    def _get_command_parser(parser, command):
+        for action in parser._actions:
+            if action.choices is not None and 'SubParsersAction' in str(action.__class__):
+                return action.choices[command]
+        raise ValueError('No parser for %s found' % command)
+
+    def write_options_group(self, group, contents, with_title=True):
+        def is_positional_group(group):
+            return any(not o.option_strings for o in group._group_actions)
+
+        def get_help(option):
+            text = dedent((option.help or '') % option.__dict__)
+            return '\n'.join('| ' + line for line in text.splitlines())
+
+        def shipout(text):
+            for line in text:
+                contents.append(indent(line, ' ' * 4))
+
+        if not group._group_actions:
+            return
+
+        if with_title:
+            contents.append(group.title)
+        text = []
+
+        if is_positional_group(group):
+            for option in group._group_actions:
+                text.append(option.metavar)
+                text.append(indent(option.help or '', ' ' * 4))
+            shipout(text)
+            return
+
+        options = []
+        for option in group._group_actions:
+            if option.metavar:
+                option_fmt = '``%%s %s``' % option.metavar
+            else:
+                option_fmt = '``%s``'
+            option_str = ', '.join(option_fmt % s for s in option.option_strings)
+            options.append((option_str, option))
+        for option_str, option in options:
+            help = indent(get_help(option), ' ' * 4)
+            text.append(option_str)
+            text.append(help)
+
+        text.append("")
+        shipout(text)
+
+    def run(self):
+        command = self.arguments[0]
+        parser = self._get_command_parser(build_parser(), command)
+
+        full_command = 'borg-import ' + command
+        headline = '::\n\n    ' + full_command
+
+        if any(len(o.option_strings) for o in parser._actions):
+            headline += ' <options>'
+
+        # Add the metavars of the parameters to the synopsis line
+        for option in parser._actions:
+            if not option.option_strings:
+                headline += ' ' + option.metavar
+
+        headline += '\n\n'
+
+        # Final result will look like:
+        # borg-import something <options> FOO_BAR REPOSITORY
+        contents = headline.splitlines()
+
+        for group in parser._action_groups:
+            self.write_options_group(group, contents)
+
+        if parser.epilog:
+            contents.append('Description')
+            contents.append('~~~~~~~~~~~')
+            contents.append('')
+
+        node = nodes.paragraph()
+        nested_parse_with_titles(self.state, StringList(contents), node)
+        gen_nodes = [node]
+
+        if parser.epilog:
+            paragraphs = parser.epilog.split('\n\n')
+            for paragraph in paragraphs:
+                node = nodes.paragraph()
+                nested_parse_with_titles(self.state, StringList(paragraph.split('\n')), node)
+                gen_nodes.append(node)
+
+        return gen_nodes
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.add_directive('generate-usage', GenerateUsageDirective)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,12 +5,16 @@
 Usage
 =====
 
-|project_name| consists of a number of commands. Each command accepts
-a number of arguments and options. The following sections will describe each
-command in detail.
+``borg-import`` consists of a number of commands, one for each
+backup system supported. Each accepts a number of arguments and
+options. The following sections will describe each in detail.
 
 General
 -------
 
-...
+.. _rsnapshot:
 
+borg-import rsnapshot
+---------------------
+
+.. generate-usage:: rsnapshot


### PR DESCRIPTION
This is an alternate approach to generating the usage that doesn't use generated files.

So docs always exactly up to date, no .gitattributes or merge conflicts, no confusion about generated files being committed. But also: harder to debug, since you don't directly see the generated rst.

Fixes #18