### PR TITLE
Fixed travis-ci by requiring virtualenv<14.0 compatible tools

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
 virtualenv<14.0
-tox
-pytest
+tox<3.10
+pytest<5.0
 pytest-cov


### PR DESCRIPTION
Well the problem is with the below code in developement.txt
```
virtualenv<14.0
```
Currently, This installs virtualenv with version less than 14.0

Newer version of tox adds "--no-download" with virtualenv which does not exists in virtualenv<14.0
Similar issues with pytest