### PR TITLE
Update .travis.yml to use Ubuntu Xenial (16.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ matrix:
     include:
         - python: 3.4
           os: linux
-          dist: trusty
+          dist: xenial
           env: TOXENV=py34
         - python: 3.5
           os: linux
-          dist: trusty
+          dist: xenial
           env: TOXENV=py35
         - python: 3.5
           os: linux
-          dist: trusty
+          dist: xenial
           env: TOXENV=flake8
 
 install:


### PR DESCRIPTION
From the backports repo, a build for Ubuntu Trusty is no longer
available, so bumping version up to Ubuntu Xenial to continue to
use the packages available. Note that Ubuntu Xenial will continue
to be supported until April 2021.