### PR TITLE
Bump Python requirement to 3.5+ and add 3.5+ tags/testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,22 @@ cache:
 
 matrix:
     include:
-        - python: 3.4
-          os: linux
-          dist: xenial
-          env: TOXENV=py34
         - python: 3.5
           os: linux
           dist: xenial
           env: TOXENV=py35
+        - python: 3.6
+          os: linux
+          dist: xenial
+          env: TOXENV=py36
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py37
+        - python: 3.8
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
         - python: 3.5
           os: linux
           dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,62 @@
-sudo: required
-
 language: python
 
 cache:
     directories:
         - $HOME/.cache/pip
 
-matrix:
+os: linux
+
+jobs:
     include:
-        - python: 3.5
-          os: linux
-          dist: xenial
+        # Ubuntu Xenial (16.04)
+        - dist: xenial
+          python: 3.5
           env: TOXENV=py35
-        - python: 3.6
-          os: linux
-          dist: xenial
+        - dist: xenial
+          python: 3.6
           env: TOXENV=py36
-        - python: 3.7
-          os: linux
-          dist: xenial
+        - dist: xenial
+          python: 3.7
           env: TOXENV=py37
-        - python: 3.8
-          os: linux
-          dist: xenial
+        - dist: xenial
+          python: 3.8
           env: TOXENV=py38
-        - python: 3.5
-          os: linux
-          dist: xenial
+        - dist: xenial
+          python: 3.5
+          env: TOXENV=flake8
+        
+        # Ubuntu Bionic (18.04)
+        - dist: bionic
+          python: 3.5
+          env: TOXENV=py35
+        - dist: bionic
+          python: 3.6
+          env: TOXENV=py36
+        - dist: bionic
+          python: 3.7
+          env: TOXENV=py37
+        - dist: bionic
+          python: 3.8
+          env: TOXENV=py38
+        - dist: bionic
+          python: 3.5
+          env: TOXENV=flake8
+        
+        # Ubuntu Focal (20.04)
+        - dist: focal
+          python: 3.5
+          env: TOXENV=py35
+        - dist: focal
+          python: 3.6
+          env: TOXENV=py36
+        - dist: focal
+          python: 3.7
+          env: TOXENV=py37
+        - dist: focal
+          python: 3.8
+          env: TOXENV=py38
+        - dist: focal
+          python: 3.5
           env: TOXENV=flake8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,55 +8,28 @@ os: linux
 
 jobs:
     include:
-        # Ubuntu Xenial (16.04)
+        # Ubuntu Xenial (16.04) / Python 3.5
         - dist: xenial
           python: 3.5
           env: TOXENV=py35
-        - dist: xenial
-          python: 3.6
-          env: TOXENV=py36
-        - dist: xenial
-          python: 3.7
-          env: TOXENV=py37
-        - dist: xenial
-          python: 3.8
-          env: TOXENV=py38
-        - dist: xenial
-          python: 3.5
-          env: TOXENV=flake8
         
-        # Ubuntu Bionic (18.04)
-        - dist: bionic
-          python: 3.5
-          env: TOXENV=py35
+        # Ubuntu Bionic (18.04) / Python 3.6-3.7
         - dist: bionic
           python: 3.6
           env: TOXENV=py36
         - dist: bionic
           python: 3.7
           env: TOXENV=py37
-        - dist: bionic
-          python: 3.8
-          env: TOXENV=py38
-        - dist: bionic
-          python: 3.5
-          env: TOXENV=flake8
         
-        # Ubuntu Focal (20.04)
-        - dist: focal
-          python: 3.5
-          env: TOXENV=py35
-        - dist: focal
-          python: 3.6
-          env: TOXENV=py36
-        - dist: focal
-          python: 3.7
-          env: TOXENV=py37
+        # Ubuntu Focal (20.04) / Python 3.8+ w/Flake for 3.8
         - dist: focal
           python: 3.8
           env: TOXENV=py38
         - dist: focal
-          python: 3.5
+          python: 3.9
+          env: TOXENV=py39
+        - dist: focal
+          python: 3.8
           env: TOXENV=flake8
 
 install:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,9 +3,6 @@
 set -e
 set -x
 
-is_xenial=$(lsb_release -r | grep 16.04 &>/dev/null && echo "y" || echo "n")
-is_focal=$(lsb_release -r | grep 20.04 &>/dev/null && echo "y" || echo "n")
-
 sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
 sudo apt-get install -y fakeroot borgbackup

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,7 +7,7 @@ sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
 sudo apt-get install -y fakeroot borgbackup
 
-pip install 'virtualenv=16.7.7'
+pip install 'virtualenv==16.7.7'
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
 pip install -r requirements.d/development.txt

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,13 +7,7 @@ sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
 sudo apt-get install -y fakeroot borgbackup
 
-# Chicken/egg problem with Python 3.8... current Travis pip is not
-# compatible with Python 3.8, but we need a newer one to fix it...
-# Solution: install pip the "manual" way so that we can bootstrap.
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python get-pip.py --no-setuptools --no-wheel
-
-pip install 'virtualenv<14.0'
+pip install 'virtualenv=16.7.7'
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
 pip install -r requirements.d/development.txt

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,6 +7,12 @@ sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
 sudo apt-get install -y fakeroot borgbackup
 
+# Chicken/egg problem with Python 3.8... current Travis pip is not
+# compatible with Python 3.8, but we need a newer one to fix it...
+# Solution: install pip the "manual" way so that we can bootstrap.
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python get-pip.py --no-setuptools --no-wheel
+
 pip install 'virtualenv<14.0'
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -6,21 +6,9 @@ set -x
 is_xenial=$(lsb_release -r | grep 16.04 &>/dev/null && echo "y" || echo "n")
 is_focal=$(lsb_release -r | grep 20.04 &>/dev/null && echo "y" || echo "n")
 
-if [ "$is_focal" = "n" ]; then
-    # Only add PPA if we're not testing for Focal
-    # We technically don't use the PPA for Xenial either, but keeping it for now should be OK
-    sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
-fi
-
+sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
-sudo apt-get install -y fakeroot
-
-if [ "$is_xenial" = "y" ] || [ "$is_focal" = "y" ]; then
-    # Workaround for broken PPA
-    sudo wget -O /usr/bin/borg https://github.com/borgbackup/borg/releases/download/1.1.11/borg-linux64
-else
-    sudo apt-get install -y borgbackup
-fi
+sudo apt-get install -y fakeroot borgbackup
 
 pip install 'virtualenv'
 python -m virtualenv ~/.venv

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,7 +7,7 @@ sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
 sudo apt-get install -y fakeroot borgbackup
 
-pip install 'virtualenv==16.7.7'
+pip install 'virtualenv'
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
 pip install -r requirements.d/development.txt

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,7 +5,17 @@ set -x
 
 sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
 sudo apt-get update
-sudo apt-get install -y fakeroot borgbackup
+
+is_xenial=$(lsb_release -r | grep 16.04 &>/dev/null && echo "y" || echo "n")
+
+sudo apt-get install -y fakeroot
+
+if [ "$is_xenial" = "y" ]; then
+    # Workaround for broken PPA
+    sudo wget -O /usr/bin/borg https://github.com/borgbackup/borg/releases/download/1.1.11/borg-linux64
+else
+    sudo apt-get install -y borgbackup
+fi
 
 pip install 'virtualenv'
 python -m virtualenv ~/.venv

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,14 +3,19 @@
 set -e
 set -x
 
-sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
-sudo apt-get update
-
 is_xenial=$(lsb_release -r | grep 16.04 &>/dev/null && echo "y" || echo "n")
+is_focal=$(lsb_release -r | grep 20.04 &>/dev/null && echo "y" || echo "n")
 
+if [ "$is_focal" = "n" ]; then
+    # Only add PPA if we're not testing for Focal
+    # We technically don't use the PPA for Xenial either, but keeping it for now should be OK
+    sudo add-apt-repository -y ppa:costamagnagianfranco/borgbackup
+fi
+
+sudo apt-get update
 sudo apt-get install -y fakeroot
 
-if [ "$is_xenial" = "y" ]; then
+if [ "$is_xenial" = "y" ] || [ "$is_focal" = "y" ]; then
     # Workaround for broken PPA
     sudo wget -O /usr/bin/borg https://github.com/borgbackup/borg/releases/download/1.1.11/borg-linux64
 else

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-virtualenv==16.7.7
-tox<3.10
-pytest<5.0
+virtualenv
+tox
+pytest
 pytest-cov

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-virtualenv<14.0
+virtualenv==16.7.7
 tox<3.10
 pytest<5.0
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import sys
 from setuptools import setup, find_packages
 
-min_python = (3, 4)
+min_python = (3, 5)
 my_python = sys.version_info
 
 if my_python < min_python:
@@ -32,8 +32,10 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Archiving :: Backup',
     ],
     packages=find_packages('src'),

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: System :: Archiving :: Backup',
     ],
     packages=find_packages('src'),

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{34,35},flake8
+envlist = py{35,36,37,38},flake8
 
 [testenv]
 # Change dir to avoid import problem for cython code. The directory does

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36,37,38},flake8
+envlist = py{35,36,37,38,39},flake8
 
 [testenv]
 # Change dir to avoid import problem for cython code. The directory does


### PR DESCRIPTION
Per #33, bump the Python version requirement to v3.5+ in setup.py, and add tags to indicate that this project supports v3.5+. As such, also update tox.ini and .travis.yml to support v3.5-3.8 as well.

(This relies on the prior PR #37, which should probably be validated and merged first before reviewing this one.)

Also noting that I left flake8 at Python 3.5, assuming that the preferred style checks should be at that particular version.