### PR TITLE
added new datetime_from_dir() function to parse BackInTime folder names

### DIFF
--- a/src/borg_import/helpers/timestamps.py
+++ b/src/borg_import/helpers/timestamps.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+import time
 
 
 def datetime_from_mtime(path):
@@ -33,6 +34,37 @@ def datetime_from_string(s):
             ]:
         try:
             return datetime.strptime(s, ts_format)
+        except ValueError:
+            # didn't work with this format, try next
+            pass
+    else:
+        raise ValueError('could not parse %r' % s)
+
+
+def datetime_from_dir(d, p=4):
+    """
+    parse datetime from part of a directory name
+
+    returns a datetime object if the format could be parsed.
+    raises ValueError if not.
+    """
+    if type(d).__name__ == 'PosixPath':
+            s = d.name
+    elif type(d) == str:
+            # in case input is just a string (for testing)
+            s = d
+    # get rid of trailing -??? numbers that BackInTime adds
+    s = s[:-p].strip()
+    for ts_format in [
+            # Back In Time format
+            '%Y%m%d-%H%M%S',
+            ]:
+        try:
+            dt = datetime.strptime(s, ts_format)
+            # adjust time zone offset to get UTC
+            tz = int(time.strftime('%z')[:-2])
+            ut = dt - timedelta(hours=tz)
+            return ut
         except ValueError:
             # didn't work with this format, try next
             pass


### PR DESCRIPTION
[Back In Time](https://github.com/bit-team/backintime) uses rsync+hardlinks, but (on my machine at least) the timestamps get messed up sometimes, so I needed a more reliable way of getting the original timestamp from the directory name (e.g. `20200428-170001-777`).  It's mostly just adjusting the `strptime` format, as well as converting the time to UTC (since the folder times are in local time).  
To actually use this, a small change in `rsynchl.py` will be required.