### PR TITLE
Return timestamp from filesystem object in UTC, since borg expects UT…

### DIFF
--- a/src/borg_import/helpers/timestamps.py
+++ b/src/borg_import/helpers/timestamps.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def datetime_from_mtime(path):
@@ -10,7 +10,7 @@ def datetime_from_mtime(path):
     at backup time).
     """
     t = path.stat().st_mtime
-    return datetime.fromtimestamp(t)
+    return datetime.fromtimestamp(t, tz=timezone.utc)
 
 
 def datetime_from_string(s):


### PR DESCRIPTION
…C timestamps.

I noticed `borg-import` was giving some incorrect timestamps for an `rsynchl` backup. Here is an example of a few timestamps for an ARM SBC that I backed up with `borg-import`:

* Actual SBC:

  ```
  wjones@DietPi:~$ ls -ld --full-time /
  drwxr-xr-x 21 root root 4096 2023-11-20 18:01:08.000000000 -0500 /
  ```

* `rsync` backup:

  ```
  william@xubuntu-dtrain:/shares/wjones/backup$ ls -ld --full-time /mnt/wjones/backup/tinkerboard/2023-12-20-063019/
  drwxr-xr-x 7 william william 4096 2023-11-20 18:01:08.000000000 -0500 /mnt/wjones/backup/tinkerboard/2023-12-20-063019/
  ```

* Borg List (Archive):

  ```
  william@xubuntu-dtrain:/shares/wjones/work/2023-12-20-063019$ borg list ::tinkerboard-2023-12-20-063019 | head
  drwxr-xr-x william william        0 Mon, 2023-11-20 18:01:08 .
  ...
  ```

* Borg List (Repo):

  ```
  william@xubuntu-dtrain:/shares/wjones/work/2023-12-20-063019$ borg list -a tinkerboard-2023-12-20-063019
  tinkerboard-2023-12-20-063019        Mon, 2023-11-20 13:01:08 [af88f26cfc113fcdb4085dbfa92d044198d4a64cb3291a48921447ec93f245d9]
  ```

The SBC dir, backup dir, and timestamp of the root directory inside the archive return the same timestamp of `Mon, 2023-11-20 18:01:08`. However, `borg list` shows an archive timestamp 5 hours earlier. 

Since the `borg list` timestamp is derived from the backup root directory timestamp. I figured out that this is because `borg-import` passes a local timestamp to `borg`'s `--timestamp` option rather than a UTC timestamp.

After this patch, I get an expected timestamp for the full archive that matches the backup root directory's timestamp (timestamp of this backup directory was set to `Mon, 2023-11-20 18:01:08` for easy comparison):

```
william@xubuntu-dtrain:/shares/wjones/work$ ls --full-time
...
drwxr-xr-x 7 william william     4096 2023-11-20 18:01:08.000000000 -0500 2023-12-20-063019

william@xubuntu-dtrain:/shares/wjones/work$ borg-import rsynchl -o="-sp" --prefix=utc-test- . $BORG_REPO
...
Importing 2023-12-20-063019 (timestamp 2023-11-20 23:01:08+00:00) as utc-test-2023-12-20-063019
------------------------------------------------------------------------------
Repository: /shares/borg/wjones
Archive name: utc-test-2023-12-20-063019
Archive fingerprint: 77e901e4778b3cbd7d484e637f960703d601c10e549d5703278e17c2db83201c
Time (start): Mon, 2023-11-20 18:01:08
Time (end):   Mon, 2023-11-20 18:03:14
Duration: 2 minutes 6.89 seconds
Number of files: 125246
Utilization of max. archive size: 0%
------------------------------------------------------------------------------
                       Original size      Compressed size    Deduplicated size
This archive:                7.41 GB              4.56 GB              7.49 MB
All archives:               11.13 TB              7.61 TB              1.02 TB

                       Unique chunks         Total chunks
Chunk index:                 7900863            108563408
------------------------------------------------------------------------------

william@xubuntu-dtrain:/shares/wjones/work$ borg list -a utc-test-2023-12-20-063019
utc-test-2023-12-20-063019           Mon, 2023-11-20 18:01:08 [77e901e4778b3cbd7d484e637f960703d601c10e549d5703278e17c2db83201c]
```
