### PR TITLE
Add support for importing rsync-time-backup backups.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Usage: ``borg-import rsynchl RSYNC_ROOT BORG_REPOSITORY``
 See ``borg-import rsynchl -h`` for help.
 
 `rsync-time-backup <https://github.com/laurent22/rsync-time-backup>`_
-----------------------------
+---------------------------------------------------------------------
 
 Similar to `rsynchl`, except with timestamp extraction optimized for `rsync-time-backup` folder names.
 

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,15 @@ Usage: ``borg-import rsynchl RSYNC_ROOT BORG_REPOSITORY``
 
 See ``borg-import rsynchl -h`` for help.
 
+`rsync-time-backup <https://github.com/laurent22/rsync-time-backup>`_
+----------------------------
+
+Similar to `rsynchl`, except with timestamp extraction optimized for `rsync-time-backup` folder names.
+
+Usage: ``borg-import rsync_tmbackup --prefix=foo- RSYNC_ROOT BORG_REPOSITORY``
+
+See ``borg-import rsync_tmbackup -h`` for help.
+
 Backup tools based on rsync with hard links
 -------------------------------------------
 

--- a/src/borg_import/helpers/testsuite/test_timestamps.py
+++ b/src/borg_import/helpers/testsuite/test_timestamps.py
@@ -18,7 +18,14 @@ def test_datetime_from_mtime(tmpdir):
 
 
 def test_datetime_from_string():
-    assert datetime_from_string('1999-12-31T23:59:59') == datetime(1999, 12, 31, 23, 59, 59)
-    assert datetime_from_string('Mon Oct 31 23:35:50 UTC 2016') == datetime(2016, 10, 31, 23, 35, 50)
+    # Start with local timezone, convert to UTC, and then convert back to local.
+    assert datetime_from_string('1999-12-31T23:59:59') == datetime(1999, 12, 31, 23, 59, 59).astimezone()
+    # FIXME: strptime discards timezone info, and creates a naive time.
+    # UTC is handled specially, both in strptime and datetime_from_string;
+    # local conversions using this format may or may not work.
+    assert datetime_from_string('Mon Oct 31 23:35:50 UTC 2016') == datetime(2016, 10, 31, 23, 35, 50,
+                                                                            tzinfo=timezone.utc)
+    # rsync-time-backup format.
+    assert datetime_from_string('2022-12-21-063019') == datetime(2022, 12, 21, 6, 30, 19).astimezone()
     with pytest.raises(ValueError):
         datetime_from_string('total crap')

--- a/src/borg_import/helpers/testsuite/test_timestamps.py
+++ b/src/borg_import/helpers/testsuite/test_timestamps.py
@@ -18,14 +18,27 @@ def test_datetime_from_mtime(tmpdir):
 
 
 def test_datetime_from_string():
-    # Start with local timezone, convert to UTC, and then convert back to local.
-    assert datetime_from_string('1999-12-31T23:59:59') == datetime(1999, 12, 31, 23, 59, 59).astimezone()
-    # FIXME: strptime discards timezone info, and creates a naive time.
-    # UTC is handled specially, both in strptime and datetime_from_string;
-    # local conversions using this format may or may not work.
-    assert datetime_from_string('Mon Oct 31 23:35:50 UTC 2016') == datetime(2016, 10, 31, 23, 35, 50,
-                                                                            tzinfo=timezone.utc)
+    dfs = datetime_from_string('1999-12-31T23:59:59')
+    dt_trg = datetime(1999, 12, 31, 23, 59, 59).astimezone(tz=timezone.utc)
+    assert dfs == dt_trg
+    # Of course, two datetimes can be equal in different timezones. Make
+    # sure the timezone info matches UTC, which borg itself expects.
+    assert dfs.tzinfo == dt_trg.tzinfo == timezone.utc
+
+    # FIXME: When this format is passed to datetime_from_string, the internal
+    # strptime discards timezone info, and creates a naive time.
+    # UTC is handled specially inside datetime_from_string to accommodate
+    # strptime's quirks; local conversions using this format may or may not work.
+    dfs = datetime_from_string('Mon Oct 31 23:35:50 UTC 2016')
+    dt_trg = datetime(2016, 10, 31, 23, 35, 50, tzinfo=timezone.utc)
+    assert dfs == dt_trg
+    assert dfs.tzinfo == dt_trg.tzinfo == timezone.utc
+
     # rsync-time-backup format.
-    assert datetime_from_string('2022-12-21-063019') == datetime(2022, 12, 21, 6, 30, 19).astimezone()
+    dfs = datetime_from_string('2022-12-21-063019')
+    dt_trg = datetime(2022, 12, 21, 6, 30, 19).astimezone(tz=timezone.utc)
+    assert dfs == dt_trg
+    assert dfs.tzinfo == dt_trg.tzinfo == timezone.utc
+
     with pytest.raises(ValueError):
         datetime_from_string('total crap')

--- a/src/borg_import/helpers/timestamps.py
+++ b/src/borg_import/helpers/timestamps.py
@@ -10,6 +10,7 @@ def datetime_from_mtime(path):
     at backup time).
     """
     t = path.stat().st_mtime
+    # Borg needs UTC timestamps.
     return datetime.fromtimestamp(t, tz=timezone.utc)
 
 
@@ -17,7 +18,7 @@ def datetime_from_string(s):
     """
     parse datetime from a string
 
-    returns a datetime object if the format could be parsed.
+    returns a UTC-aware datetime object if the format could be parsed.
     raises ValueError if not.
     """
     s = s.strip()
@@ -29,10 +30,29 @@ def datetime_from_string(s):
             '%Y-%m-%d %H:%M',
             # date tool output [C / en_US locale]:
             '%a %b %d %H:%M:%S %Z %Y',
+            # rsync-time-backup format
+            '%Y-%m-%d-%H%M%S'
             # for more, see https://xkcd.com/1179/
             ]:
         try:
-            return datetime.strptime(s, ts_format)
+            if ts_format in ('%a %b %d %H:%M:%S %Z %Y',) and 'UTC' in s:
+                # %Z returns a naive datetime, despite a timezone being specified.
+                # However, strptime %Z only tends to work on local times and
+                # UTC.
+                #
+                # Per astimezone docs:
+                # If self is naive, it is presumed to represent time in the
+                # system timezone.
+                #
+                # If we had a UTC time zone, prevent conversion to aware
+                # datetime from assuming a local timezone before conversion
+                # to UTC.
+                #
+                # If "UTC" wasn't specified, assume the timezone specified
+                # was local and hope for the best.
+                return datetime.strptime(s, ts_format).replace(tzinfo=timezone.utc)
+            else:
+                return datetime.strptime(s, ts_format).astimezone(tz=timezone.utc)
         except ValueError:
             # didn't work with this format, try next
             pass

--- a/src/borg_import/helpers/timestamps.py
+++ b/src/borg_import/helpers/timestamps.py
@@ -10,7 +10,7 @@ def datetime_from_mtime(path):
     at backup time).
     """
     t = path.stat().st_mtime
-    # Borg needs UTC timestamps.
+    # Borg needs tz-aware timestamps in UTC timezone.
     return datetime.fromtimestamp(t, tz=timezone.utc)
 
 
@@ -18,7 +18,9 @@ def datetime_from_string(s):
     """
     parse datetime from a string
 
-    returns a UTC-aware datetime object if the format could be parsed.
+    returns a tz-aware datetime object in UTC timezone if the format could be
+    parsed.
+
     raises ValueError if not.
     """
     s = s.strip()
@@ -44,14 +46,15 @@ def datetime_from_string(s):
                 # If self is naive, it is presumed to represent time in the
                 # system timezone.
                 #
-                # If we had a UTC time zone, prevent conversion to aware
+                # If we had a UTC timezone, prevent conversion to aware
                 # datetime from assuming a local timezone before conversion
                 # to UTC.
-                #
-                # If "UTC" wasn't specified, assume the timezone specified
-                # was local and hope for the best.
                 return datetime.strptime(s, ts_format).replace(tzinfo=timezone.utc)
             else:
+                # If "UTC" wasn't specified using the above ts_format, assume
+                # the timezone specified was local and hope for the best.
+                # This handles all other ts_formats as well, which are assumed
+                # to be local since they don't carry timezone.
                 return datetime.strptime(s, ts_format).astimezone(tz=timezone.utc)
         except ValueError:
             # didn't work with this format, try next

--- a/src/borg_import/rsync_tmbackup.py
+++ b/src/borg_import/rsync_tmbackup.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+from .helpers.discover import discover, parser
+from .helpers.names import make_name
+from .helpers.timestamps import datetime_from_string
+
+
+def get_tmbackup_snapshots(root, prefix):
+    """Get all snapshot metadata discovered in the rsync root directory."""
+    regex = re.compile(r'(?P<snapshot_date>.+)')
+
+    if not Path("backup.marker").exists():
+        raise FileNotFoundError("backup.marker file should exist for rsync-time-backup import")
+
+    for path in discover(str(root), 1):
+        parsed = parser(path, regex)
+        if parsed is not None and parsed['snapshot_date'] not in ("latest",):
+            abs_path = root / path
+            meta = dict(
+                name=make_name("".join([prefix, parsed['snapshot_date']])),
+                path=abs_path,
+                timestamp=datetime_from_string(path),
+            )
+            yield meta
+        elif parsed['snapshot_date'] in ("latest",):
+            # latest is a symlink to the most recent build. Import it anyway
+            # in case user wants to do borg mount/has existing references
+            # to latest.
+            abs_path = root / path
+            timestamp = Path("latest").resolve().name
+            meta = dict(
+                name=make_name("".join([prefix, "latest"])),
+                path=abs_path,
+                timestamp=datetime_from_string(timestamp),
+            )
+            yield meta


### PR DESCRIPTION
[rsync-time-backup](https://github.com/laurent22/rsync-time-backup) was my previous preferred backup solution. You can import backups from this program just fine using `rsynchl`.

However, for `rsync_tmbackup`, archives timestamps are better derived from each folder name rather than folder `mtime`. Since folder names are timestamps, I mandate using `--prefix`.

Additionally, thanks to parsing times from folder names, this PR marks the first use of `datetime_from_string` outside of tests. I modified `datetime_from_string` to return UTC-aware `datetime`s. There are at least two issues with using `strptime` for aware `datetime`s:

1. Ignores time zones in `%Z`, except for [small number of cases](https://bugs.python.org/issue22377).
2. Even if `%Z` parses successfully, only `%z` [returns](https://docs.python.org/3/library/datetime.html#technical-detail) a timezone-aware `datetime`.

Therefore, I improvised to make `%a %b %d %H:%M:%S %Z %Y` formatting (the only supported format w/ a time zone) to return a UTC-aware timestamp. If you don't like this at all, I'm open to changing it.