### PR TITLE
🔧 fix(pytest): move pytest config to [tool.pytest.ini_options]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ where = ["src"]
 [tool.setuptools_scm]
 write_to = "src/borg_import/_version.py"
 
-[tool.pytest]
+[tool.pytest.ini_options]
 python_files = "testsuite/*.py"
 testpaths = ["src"]
 


### PR DESCRIPTION
Switched from [tool.pytest] to [tool.pytest.ini_options] in pyproject.toml to align with pytest's expected configuration format and avoid schema errors. ⚠️

Although it may seem inconsistent with other tools, the pytest team has reserved [tool.pytest] for future use with a richer TOML-native configuration 📦. The [tool.pytest.ini_options] section serves as a compatibility bridge with the existing .ini-style configuration system 🔄.

📚 As per: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml