### PR TITLE
test and fixes for rsync_tmbackup importer

### DIFF
--- a/src/borg_import/rsync_tmbackup.py
+++ b/src/borg_import/rsync_tmbackup.py
@@ -10,7 +10,7 @@ def get_tmbackup_snapshots(root, prefix):
     """Return metadata for all snapshots discovered in the rsync root directory."""
     regex = re.compile(r"(?P<snapshot_date>.+)")
 
-    if not Path("backup.marker").exists():
+    if not (root / "backup.marker").exists():
         raise FileNotFoundError("The backup.marker file must exist for rsync-time-backup import")
 
     for path in discover(str(root), 1):

--- a/src/borg_import/testsuite/test_borg.py
+++ b/src/borg_import/testsuite/test_borg.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 from borg_import.main import main
 

--- a/src/borg_import/testsuite/test_borg.py
+++ b/src/borg_import/testsuite/test_borg.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 from borg_import.main import main
 
@@ -25,7 +26,6 @@ def test_borg_import(tmpdir, monkeypatch):
 
     # Create archives in the source repository
     subprocess.check_call(["borg", "create", f"{source_repo}::archive1", "."], cwd=str(archive1_data))
-
     subprocess.check_call(["borg", "create", f"{source_repo}::archive2", "."], cwd=str(archive2_data))
 
     # Initialize the target repository
@@ -49,7 +49,6 @@ def test_borg_import(tmpdir, monkeypatch):
     extract_dir2 = tmpdir.mkdir("extract2")
 
     subprocess.check_call(["borg", "extract", f"{target_repo}::archive1"], cwd=str(extract_dir1))
-
     subprocess.check_call(["borg", "extract", f"{target_repo}::archive2"], cwd=str(extract_dir2))
 
     # Verify the contents of the extracted archives

--- a/src/borg_import/testsuite/test_tmbackup.py
+++ b/src/borg_import/testsuite/test_tmbackup.py
@@ -1,0 +1,51 @@
+import subprocess
+from pathlib import Path
+
+def test_rsync_tmbackup_import(tmpdir, monkeypatch):
+    """Test importing rsync-time-backup style snapshots into a borg repo."""
+    src = Path(str(tmpdir.mkdir("tmbackup")))
+
+    # backup.marker is required by rsync-time-backup
+    (src / "backup.marker").touch()
+
+    # two timestamped snapshot directories
+    snap1 = src / "2023-01-01-120000"
+    snap1.mkdir()
+    (snap1 / "file1.txt").write_text("This is file 1 in snap1")
+
+    snap2 = src / "2023-01-02-120000"
+    snap2.mkdir()
+    (snap2 / "file1.txt").write_text("This is file 1 in snap2")
+
+    target_repo = Path(str(tmpdir.mkdir("target_repo")))
+
+    # Initialize the target repository
+    subprocess.check_call(["borg", "init", "--encryption=none", str(target_repo)])
+
+    # Run the importer
+    monkeypatch.setattr(
+        "sys.argv",
+        ["borg-import", "rsync_tmbackup", "--prefix", "backup-", str(src), str(target_repo)],
+    )
+
+    from borg_import.main import main
+    main()
+
+    # Verify archives were created
+    output = subprocess.check_output(
+        ["borg", "list", "--short", str(target_repo)]
+    ).decode()
+    archives = output.splitlines()
+
+    assert len(archives) == 2
+    assert any("2023-01-01" in a for a in archives)
+    assert any("2023-01-02" in a for a in archives)
+
+    # Extract and verify file contents
+    extract_dir = Path(str(tmpdir.mkdir("extracted")))
+    first_archive = f"{target_repo}::{archives[0]}"
+    subprocess.check_call(["borg", "extract", first_archive], cwd=str(extract_dir))
+
+    restored = extract_dir / "file1.txt"
+    assert restored.exists()
+    assert restored.read_text() == "This is file 1 in snap1"

--- a/src/borg_import/testsuite/test_tmbackup.py
+++ b/src/borg_import/testsuite/test_tmbackup.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 
+
 def test_rsync_tmbackup_import(tmpdir, monkeypatch):
     """Test importing rsync-time-backup style snapshots into a borg repo."""
     src = Path(str(tmpdir.mkdir("tmbackup")))
@@ -24,17 +25,15 @@ def test_rsync_tmbackup_import(tmpdir, monkeypatch):
 
     # Run the importer
     monkeypatch.setattr(
-        "sys.argv",
-        ["borg-import", "rsync_tmbackup", "--prefix", "backup-", str(src), str(target_repo)],
+        "sys.argv", ["borg-import", "rsync_tmbackup", "--prefix", "backup-", str(src), str(target_repo)]
     )
 
     from borg_import.main import main
+
     main()
 
     # Verify archives were created
-    output = subprocess.check_output(
-        ["borg", "list", "--short", str(target_repo)]
-    ).decode()
+    output = subprocess.check_output(["borg", "list", "--short", str(target_repo)]).decode()
     archives = output.splitlines()
 
     assert len(archives) == 2


### PR DESCRIPTION
### Summary
Added a test for the rsync_tmbackup importer.

### Changes
- Added a test that simulates rsync-time-backup style folders
- Verifies archives can be imported into the target repository
- Improves test coverage for the rsync_tmbackup importer

### Reason
This extends importer test coverage using the same integration-style approach already used in the existing test suite.